### PR TITLE
Require friendsofsymfony/elastica-bundle dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.6",
-        "friendsofsymfony/elastica-bundle": "^3",
+        "friendsofsymfony/elastica-bundle": "dev-master",
         "enqueue/enqueue-bundle": "^0.6|^0.7",
         "enqueue/enqueue": "^0.6|^0.7"
     },


### PR DESCRIPTION
friendsofsymfony/elastica-bundle master branch now support elasticsearch 5.x. It would be good to allow use it with enqueue/elastica-bundle