### PR TITLE
Add ability to change used context.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,6 +16,7 @@ class Configuration implements ConfigurationInterface
         $rootNode = $tb->root('enqueue_elastica');
         $rootNode
             ->children()
+                ->scalarNode('context')->isRequired()->defaultValue('enqueue.transport.context')->cannotBeEmpty()->end()
                 ->arrayNode('doctrine')
                     ->children()
                         ->arrayNode('queue_listeners')

--- a/DependencyInjection/EnqueueElasticaExtension.php
+++ b/DependencyInjection/EnqueueElasticaExtension.php
@@ -21,6 +21,8 @@ class EnqueueElasticaExtension extends Extension
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
+        $container->setAlias('enqueue_elastica.context', $config['context']);
+
         if (false == empty($config['doctrine']['queue_listeners'])) {
             foreach ($config['doctrine']['queue_listeners'] as $listenerConfig) {
                 $listenerId = sprintf(
@@ -31,7 +33,7 @@ class EnqueueElasticaExtension extends Extension
 
                 $container->register($listenerId, SyncIndexWithObjectChangeListener::class)
                     ->setPublic(true)
-                    ->addArgument(new Reference('enqueue.transport.context'))
+                    ->addArgument(new Reference('enqueue_elastica.context'))
                     ->addArgument($listenerConfig['model_class'])
                     ->addArgument($listenerConfig)
                     ->addTag('doctrine.event_subscriber', ['connection' => $listenerConfig['connection']])

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,7 +22,7 @@ services:
       class: 'Enqueue\ElasticaBundle\Persister\Listener\PurgePopulateQueueListener'
       public: true
       arguments:
-          - '@enqueue.transport.context'
+          - '@enqueue_elastica.context'
       tags:
           -  { name: 'kernel.event_subscriber' }
 
@@ -30,7 +30,7 @@ services:
       class: 'Enqueue\ElasticaBundle\Persister\QueuePagerPersister'
       public: true
       arguments:
-          - '@enqueue.transport.context'
+          - '@enqueue_elastica.context'
           - '@fos_elastica.persister_registry'
           - '@event_dispatcher'
       tags:


### PR DESCRIPTION
fixes https://github.com/php-enqueue/enqueue-dev/issues/308

To change the context:

```yaml
# config/packages/enqueue_elastica.yml

enqueue_elastica:
    context: 'your_custom_context_service_id'
```