### PR TITLE
Add ability to set repository method on listeners

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,7 +34,9 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('index_name')->isRequired()->cannotBeEmpty()->end()
                                     ->scalarNode('type_name')->isRequired()->cannotBeEmpty()->end()
                                     ->scalarNode('model_class')->isRequired()->cannotBeEmpty()->end()
-                                    ->scalarNode('model_id')->defaultValue('id')->cannotBeEmpty()->end()->end()
+                                    ->scalarNode('model_id')->defaultValue('id')->cannotBeEmpty()->end()
+                                    ->scalarNode('repository_method')->defaultValue('find')->cannotBeEmpty()->end()
+                    ->end()
         ;
 
         return $tb;

--- a/Doctrine/Queue/SyncIndexWithObjectChangeProcessor.php
+++ b/Doctrine/Queue/SyncIndexWithObjectChangeProcessor.php
@@ -59,10 +59,13 @@ final class SyncIndexWithObjectChangeProcessor implements PsrProcessor, CommandS
             return Result::reject('The message data misses id');
         }
         if (false == isset($data['index_name'])) {
-            return Result::reject('The message data misses id');
+            return Result::reject('The message data misses index_name');
         }
         if (false == isset($data['type_name'])) {
-            return Result::reject('The message data misses id');
+            return Result::reject('The message data misses type_name');
+        }
+        if (false == isset($data['repository_method'])) {
+            return Result::reject('The message data misses repository_method');
         }
 
         $action = $data['action'];
@@ -70,13 +73,14 @@ final class SyncIndexWithObjectChangeProcessor implements PsrProcessor, CommandS
         $id = $data['id'];
         $index = $data['index_name'];
         $type = $data['type_name'];
+        $repositoryMethod = $data['repository_method'];
 
         $repository = $this->doctrine->getManagerForClass($modelClass)->getRepository($modelClass);
         $persister = $this->persisterRegistry->getPersister($index, $type);
 
         switch ($action) {
             case self::UPDATE_ACTION:
-                if (false == $object = $repository->find($id)) {
+                if (false == $object = $repository->{$repositoryMethod}($id)) {
                     $persister->deleteById($id);
 
                     return Result::ack(sprintf('The object "%s" with id "%s" could not be found.', $modelClass, $id));
@@ -92,7 +96,7 @@ final class SyncIndexWithObjectChangeProcessor implements PsrProcessor, CommandS
 
                 return self::ACK;
             case self::INSERT_ACTION:
-                if (false == $object = $repository->find($id)) {
+                if (false == $object = $repository->{$repositoryMethod}($id)) {
                     $persister->deleteById($id);
 
                     return Result::ack(sprintf('The object "%s" with id "%s" could not be found.', $modelClass, $id));

--- a/Doctrine/SyncIndexWithObjectChangeListener.php
+++ b/Doctrine/SyncIndexWithObjectChangeListener.php
@@ -85,6 +85,7 @@ final class SyncIndexWithObjectChangeListener implements EventSubscriber
             'id' => $id,
             'index_name' => $this->config['index_name'],
             'type_name' => $this->config['type_name'],
+            'repository_method' => $this->config['repository_method'],
         ]));
 
         $this->context->createProducer()->send($queue, $message);


### PR DESCRIPTION
When retrieving object from the `SyncIndexWithObjectChangeProcessor` it use a lot of non optimized query to retrieve all relations from the retrieved object, this PR allow to set a custom `repository_method` in the listener configuration : 

```
enqueue_elastica:
    doctrine:
        queue_listeners:
            -
              index_name: app_index
              type_name: user
              model_class: App\Entity\User
              repository_method: findOneWithJoins
```

NB : Sorry I cannot find how to propose patch for this feature. So I open a pull request on this, let me know how to contribute and I will do it after that.