### PR TITLE
Missing argument for createReplyMessage()

### DIFF
--- a/Queue/PopulateProcessor.php
+++ b/Queue/PopulateProcessor.php
@@ -82,7 +82,7 @@ final class PopulateProcessor implements Processor, CommandSubscriberInterface, 
             $e->getLine()
         );
 
-        return $this->createReplyMessage($context, $message, $errorMessage);
+        return $this->createReplyMessage($context, $message, $objectsCount, $errorMessage);
     }
 
     private function createReplyMessage(Context $context, Message $message, int $objectsCount, string $error = null): Message


### PR DESCRIPTION
Hello everyone,

I think there is a small Bug in the PopulateProcessor.
Method createExceptionReplyMessage calls createReplyMessage with the error message as third argument, although it should receive he objectCount as third and the error message as fourth argument.
This could lead to unexpected behaviour, since replyMessage->setProperty('fos-populate-error', $error) never gets called.