### PR TITLE
 Fixes #823 - Cannot update an entity more than once

### DIFF
--- a/Doctrine/Queue/SyncIndexWithObjectChangeProcessor.php
+++ b/Doctrine/Queue/SyncIndexWithObjectChangeProcessor.php
@@ -81,6 +81,8 @@ final class SyncIndexWithObjectChangeProcessor implements Processor, CommandSubs
                         $persister->deleteOne($object);
                     }
                 }
+                
+                $repository->clear();
 
                 return Result::ack();
             case self::INSERT_ACTION:
@@ -93,6 +95,8 @@ final class SyncIndexWithObjectChangeProcessor implements Processor, CommandSubs
                 if ($persister->handlesObject($object) && $this->indexable->isObjectIndexable($index, $type, $object)) {
                     $persister->insertOne($object);
                 }
+                
+                $repository->clear();
 
                 return Result::ack();
             case self::REMOVE_ACTION:


### PR DESCRIPTION
Clear repository after update to allow refreshing on subsequent calls.