### PR TITLE
Updates the dispatch() event parameter order for Symfony 4.3+

### DIFF
--- a/Persister/QueuePagerPersister.php
+++ b/Persister/QueuePagerPersister.php
@@ -58,7 +58,7 @@ final class QueuePagerPersister implements PagerPersisterInterface
         $objectPersister = $this->registry->getPersister($options['indexName'], $options['typeName']);
 
         $event = new PrePersistEvent($pager, $objectPersister, $options);
-        $this->dispatcher->dispatch(Events::PRE_PERSIST, $event);
+        $this->dispatcher->dispatch($event, Events::PRE_PERSIST);
         $pager = $event->getPager();
         $options = $event->getOptions();
 
@@ -119,7 +119,7 @@ final class QueuePagerPersister implements PagerPersisterInterface
                     $errorMessage,
                     $data['options']
                 );
-                $this->dispatcher->dispatch(Events::POST_ASYNC_INSERT_OBJECTS, $event);
+                $this->dispatcher->dispatch($event, Events::POST_ASYNC_INSERT_OBJECTS);
             }
 
             if (microtime(true) > $limitTime) {
@@ -128,6 +128,6 @@ final class QueuePagerPersister implements PagerPersisterInterface
         }
 
         $event = new PostPersistEvent($pager, $objectPersister, $options);
-        $this->dispatcher->dispatch(Events::POST_PERSIST, $event);
+        $this->dispatcher->dispatch($event, Events::POST_PERSIST);
     }
 }


### PR DESCRIPTION
This is something that goes along with this [issue](https://github.com/FriendsOfSymfony/FOSElasticaBundle/issues/1530) and [pull request](https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1531) for FOSElasticaBundle. In Symfony 4.3, the order of the parameters changed for the `dispatch()` event.

I'm not good at all with PHPUnit, and I don't understand the tests they're running on FOSElasticaBundle, so the tests are failing there and they haven't been able to merge it yet. I'll have to do more work to get the tests updated properly before they'll merge I'd guess.