### PR TITLE
Fixes #902 - Allow configurable message delivery delay

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,6 +36,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('model_class')->isRequired()->cannotBeEmpty()->end()
                                     ->scalarNode('model_id')->defaultValue('id')->cannotBeEmpty()->end()
                                     ->scalarNode('repository_method')->defaultValue('find')->cannotBeEmpty()->end()
+                                    ->scalarNode('delivery_delay')->defaultNull()->end()
                     ->end()
         ;
 

--- a/Doctrine/SyncIndexWithObjectChangeListener.php
+++ b/Doctrine/SyncIndexWithObjectChangeListener.php
@@ -85,6 +85,6 @@ final class SyncIndexWithObjectChangeListener implements EventSubscriber
             'repository_method' => $this->config['repository_method'],
         ]));
 
-        $this->context->createProducer()->send($queue, $message);
+        $this->context->createProducer()->setDeliveryDelay($this->config['delivery_delay'])->send($queue, $message);
     }
 }


### PR DESCRIPTION
This commit will allow a configurable delay for each queue_listener. For example:

```
enqueue_elastica:
    transport: default
    doctrine:
        queue_listeners:
            - index_name: title
              type_name: title
              model_class: App\Domain\Model\Metadata\Title
              delivery_delay: 5000
```

It may be improved with a global default value, but I'm unfamiliar with how to achieve it. 