### PR TITLE
Symfony 5.0 Update

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,8 +12,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
+        
         $tb = new TreeBuilder('enqueue_elastica');
-        $rootNode = $tb->getRootNode();
+        if (method_exists($tb, 'getRootNode')) {
+            $rootNode = $tb->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $tb->root('enqueue_elastica');
+        }
         $rootNode
             ->children()
                 ->booleanNode('enabled')->defaultValue(true)->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('enqueue_elastica');
+        $tb = new TreeBuilder('enqueue_elastica');
+        $rootNode = $tb->getRootNode();
         $rootNode
             ->children()
                 ->booleanNode('enabled')->defaultValue(true)->end()


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0