### PR TITLE
Allow FOSElasticaBundle v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^7.1",
         "symfony/framework-bundle": "^4.0|^5.0",
-        "friendsofsymfony/elastica-bundle": "^5.0",
+        "friendsofsymfony/elastica-bundle": "^5.0|^6.0",
         "enqueue/enqueue-bundle": "^0.10"
     },
     "autoload": {


### PR DESCRIPTION
This bundle should work with FOSElasticaBundle v6.