### PR TITLE
V6 compatibility

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,7 +38,6 @@ class Configuration implements ConfigurationInterface
                                     ->booleanNode('remove')->defaultTrue()->end()
                                     ->scalarNode('connection')->defaultValue('default')->cannotBeEmpty()->end()
                                     ->scalarNode('index_name')->isRequired()->cannotBeEmpty()->end()
-                                    ->scalarNode('type_name')->isRequired()->cannotBeEmpty()->end()
                                     ->scalarNode('model_class')->isRequired()->cannotBeEmpty()->end()
                                     ->scalarNode('model_id')->defaultValue('id')->cannotBeEmpty()->end()
                                     ->scalarNode('repository_method')->defaultValue('find')->cannotBeEmpty()->end()

--- a/DependencyInjection/EnqueueElasticaExtension.php
+++ b/DependencyInjection/EnqueueElasticaExtension.php
@@ -67,9 +67,8 @@ class EnqueueElasticaExtension extends Extension
 
             foreach ($config['doctrine']['queue_listeners'] as $listenerConfig) {
                 $listenerId = sprintf(
-                    'enqueue_elastica.doctrine_queue_listener.%s.%s',
-                    $listenerConfig['index_name'],
-                    $listenerConfig['type_name']
+                    'enqueue_elastica.doctrine_queue_listener.%s',
+                    $listenerConfig['index_name']
                 );
 
                 $container->register($listenerId, SyncIndexWithObjectChangeListener::class)

--- a/DependencyInjection/EnqueueElasticaExtension.php
+++ b/DependencyInjection/EnqueueElasticaExtension.php
@@ -45,7 +45,7 @@ class EnqueueElasticaExtension extends Extension
             ->addTag('kernel.event_subscriber')
         ;
 
-        $container->register('enqueue_elastica.queue_pager_perister', QueuePagerPersister::class)
+        $container->register('enqueue_elastica.queue_pager_persister', QueuePagerPersister::class)
             ->addArgument(new Reference('enqueue_elastica.context'))
             ->addArgument(new Reference('fos_elastica.persister_registry'))
             ->addArgument(new Reference('event_dispatcher'))

--- a/Doctrine/Queue/SyncIndexWithObjectChangeProcessor.php
+++ b/Doctrine/Queue/SyncIndexWithObjectChangeProcessor.php
@@ -10,7 +10,7 @@ use FOS\ElasticaBundle\Provider\IndexableInterface;
 use Interop\Queue\Context;
 use Interop\Queue\Message;
 use Interop\Queue\Processor;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 
 final class SyncIndexWithObjectChangeProcessor implements Processor, CommandSubscriberInterface, QueueSubscriberInterface
 {

--- a/Doctrine/Queue/SyncIndexWithObjectChangeProcessor.php
+++ b/Doctrine/Queue/SyncIndexWithObjectChangeProcessor.php
@@ -49,9 +49,6 @@ final class SyncIndexWithObjectChangeProcessor implements Processor, CommandSubs
         if (false == isset($data['index_name'])) {
             return Result::reject('The message data misses index_name');
         }
-        if (false == isset($data['type_name'])) {
-            return Result::reject('The message data misses type_name');
-        }
         if (false == isset($data['repository_method'])) {
             return Result::reject('The message data misses repository_method');
         }
@@ -60,11 +57,10 @@ final class SyncIndexWithObjectChangeProcessor implements Processor, CommandSubs
         $modelClass = $data['model_class'];
         $id = $data['id'];
         $index = $data['index_name'];
-        $type = $data['type_name'];
         $repositoryMethod = $data['repository_method'];
 
         $repository = $this->doctrine->getManagerForClass($modelClass)->getRepository($modelClass);
-        $persister = $this->persisterRegistry->getPersister($index, $type);
+        $persister = $this->persisterRegistry->getPersister($index);
 
         switch ($action) {
             case self::UPDATE_ACTION:
@@ -75,7 +71,7 @@ final class SyncIndexWithObjectChangeProcessor implements Processor, CommandSubs
                 }
 
                 if ($persister->handlesObject($object)) {
-                    if ($this->indexable->isObjectIndexable($index, $type, $object)) {
+                    if ($this->indexable->isObjectIndexable($index, $object)) {
                         $persister->replaceOne($object);
                     } else {
                         $persister->deleteOne($object);
@@ -90,7 +86,7 @@ final class SyncIndexWithObjectChangeProcessor implements Processor, CommandSubs
                     return Result::ack(sprintf('The object "%s" with id "%s" could not be found.', $modelClass, $id));
                 }
 
-                if ($persister->handlesObject($object) && $this->indexable->isObjectIndexable($index, $type, $object)) {
+                if ($persister->handlesObject($object) && $this->indexable->isObjectIndexable($index, $object)) {
                     $persister->insertOne($object);
                 }
 

--- a/Doctrine/SyncIndexWithObjectChangeListener.php
+++ b/Doctrine/SyncIndexWithObjectChangeListener.php
@@ -1,7 +1,7 @@
 <?php
 namespace Enqueue\ElasticaBundle\Doctrine;
 
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Enqueue\ElasticaBundle\Doctrine\Queue\Commands;
 use Enqueue\ElasticaBundle\Doctrine\Queue\SyncIndexWithObjectChangeProcessor as SyncProcessor;

--- a/Doctrine/SyncIndexWithObjectChangeListener.php
+++ b/Doctrine/SyncIndexWithObjectChangeListener.php
@@ -100,7 +100,6 @@ final class SyncIndexWithObjectChangeListener implements EventSubscriber
             'model_id' => $this->config['model_id'],
             'id' => $id,
             'index_name' => $this->config['index_name'],
-            'type_name' => $this->config['type_name'],
             'repository_method' => $this->config['repository_method'],
         ]));
 

--- a/Persister/Listener/PurgePopulateQueueListener.php
+++ b/Persister/Listener/PurgePopulateQueueListener.php
@@ -3,7 +3,6 @@ namespace Enqueue\ElasticaBundle\Persister\Listener;
 
 use FOS\ElasticaBundle\Persister\Event\PrePersistEvent;
 use Interop\Queue\Context;
-use FOS\ElasticaBundle\Persister\Event\Events;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class PurgePopulateQueueListener implements EventSubscriberInterface
@@ -44,7 +43,7 @@ class PurgePopulateQueueListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            Events::PRE_PERSIST => 'purgePopulateQueue',
+            PrePersistEvent::class => 'purgePopulateQueue',
         ];
     }
 }

--- a/Persister/QueuePagerPersister.php
+++ b/Persister/QueuePagerPersister.php
@@ -54,7 +54,7 @@ final class QueuePagerPersister implements PagerPersisterInterface
 
         $pager->setCurrentPage($options['first_page']);
 
-        $objectPersister = $this->registry->getPersister($options['indexName'], $options['typeName']);
+        $objectPersister = $this->registry->getPersister($options['indexName']);
 
         $event = new PrePersistEvent($pager, $objectPersister, $options);
         $this->dispatcher->dispatch($event);

--- a/Persister/QueuePagerPersister.php
+++ b/Persister/QueuePagerPersister.php
@@ -3,7 +3,6 @@ namespace Enqueue\ElasticaBundle\Persister;
 
 use Enqueue\ElasticaBundle\Queue\Commands;
 use Enqueue\Util\JSON;
-use FOS\ElasticaBundle\Persister\Event\Events;
 use FOS\ElasticaBundle\Persister\Event\PostAsyncInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\Event\PostPersistEvent;
 use FOS\ElasticaBundle\Persister\Event\PrePersistEvent;
@@ -58,7 +57,7 @@ final class QueuePagerPersister implements PagerPersisterInterface
         $objectPersister = $this->registry->getPersister($options['indexName'], $options['typeName']);
 
         $event = new PrePersistEvent($pager, $objectPersister, $options);
-        $this->dispatcher->dispatch($event, Events::PRE_PERSIST);
+        $this->dispatcher->dispatch($event);
         $pager = $event->getPager();
         $options = $event->getOptions();
 
@@ -122,7 +121,7 @@ final class QueuePagerPersister implements PagerPersisterInterface
                     $errorMessage,
                     $data['options']
                 );
-                $this->dispatcher->dispatch($event, Events::POST_ASYNC_INSERT_OBJECTS);
+                $this->dispatcher->dispatch($event);
             }
 
             if (microtime(true) > $limitTime) {
@@ -131,6 +130,6 @@ final class QueuePagerPersister implements PagerPersisterInterface
         }
 
         $event = new PostPersistEvent($pager, $objectPersister, $options);
-        $this->dispatcher->dispatch($event, Events::POST_PERSIST);
+        $this->dispatcher->dispatch($event);
     }
 }

--- a/Queue/PopulateProcessor.php
+++ b/Queue/PopulateProcessor.php
@@ -48,15 +48,12 @@ final class PopulateProcessor implements Processor, CommandSubscriberInterface, 
             if (!isset($data['options']['indexName'])) {
                 return Result::reply($this->createReplyMessage($context, $message, 0,'The message is invalid. Missing indexName option.'));
             }
-            if (!isset($data['options']['typeName'])) {
-                return Result::reply($this->createReplyMessage($context, $message, 0,'The message is invalid. Missing typeName option.'));
-            }
 
             $options = $data['options'];
             $options['first_page'] = $data['page'];
             $options['last_page'] = $data['page'];
 
-            $provider = $this->pagerProviderRegistry->getProvider($options['indexName'], $options['typeName']);
+            $provider = $this->pagerProviderRegistry->getProvider($options['indexName']);
             $pager = $provider->provide($options);
             $pager->setMaxPerPage($options['max_per_page']);
             $pager->setCurrentPage($options['first_page']);

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,11 @@
     "require": {
         "php": "^7.1",
         "symfony/framework-bundle": "^4.0|^5.0",
-        "friendsofsymfony/elastica-bundle": "^5.0|^6.0",
+        "friendsofsymfony/elastica-bundle": "^6.0",
         "enqueue/enqueue-bundle": "^0.10"
+    },
+    "require-dev": {
+        "doctrine/orm": "^2.0"
     },
     "autoload": {
         "psr-4": { "Enqueue\\ElasticaBundle\\": "" }


### PR DESCRIPTION
The FOSElasticaBundle v6 has a lot of BC breaks so in order to support it, we need to drop support for v5 and fix some BC issues.