### PR TITLE
Support Elasticsearch 8 / FOSElasticaBundle 7 (PHP 8.1+)

### DIFF
--- a/Persister/QueuePagerPersister.php
+++ b/Persister/QueuePagerPersister.php
@@ -49,7 +49,7 @@ final class QueuePagerPersister implements PagerPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function insert(PagerInterface $pager, array $options = array())
+    public function insert(PagerInterface $pager, array $options = array()): void
     {
         $pager->setMaxPerPage(empty($options['max_per_page']) ? 100 : $options['max_per_page']);
 

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "keywords": ["elasticsearch", "elastica", "fos", "performance"],
     "license": "MIT",
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^8.1",
         "symfony/framework-bundle": "^6.0|^7.0",
-        "friendsofsymfony/elastica-bundle": "^6.0",
+        "friendsofsymfony/elastica-bundle": "^7.0",
         "enqueue/enqueue-bundle": "^0.10"
     },
     "require-dev": {


### PR DESCRIPTION
Bumps the dependency constraints to the Elasticsearch 8–compatible line and adapts the one signature the new interface requires:

- `friendsofsymfony/elastica-bundle`: `^6.0` → `^7.0` (the ES8 / `ruflin/elastica ^8` line)
- `php`: `^7.1|^8.0` → `^8.1`
- `QueuePagerPersister::insert()` gains the `: void` return type now declared by FOSElasticaBundle 7.x's `PagerPersisterInterface::insert()`. Without it the class fatals on autoload under FOS 7.

No behavioural change. `symfony/framework-bundle` already allowed `^6.0|^7.0`.