### PR TITLE
Treat the populate reply wait as an idle timeout so large indexes can finish

### DIFF
--- a/Persister/QueuePagerPersister.php
+++ b/Persister/QueuePagerPersister.php
@@ -119,10 +119,15 @@ final class QueuePagerPersister implements PagerPersisterInterface
         } while ($page <= $lastPage);
 
         $consumer = $this->context->createConsumer($replyQueue);
+        // Treat limit_overall_reply_time as an idle timeout rather than a hard overall cap: as long as
+        // replies keep arriving the consumers are making progress, so the deadline is pushed forward on
+        // each reply. This lets large indexes (whose population takes far longer than the timeout) finish
+        // while still aborting if the consumers go silent (e.g. all workers died).
         $limitTime = microtime(true) + $options['limit_overall_reply_time'];
         while ($sentCount) {
             if ($message = $consumer->receive($options['reply_receive_timeout'])) {
                 $sentCount--;
+                $limitTime = microtime(true) + $options['limit_overall_reply_time'];
 
                 $data = JSON::decode($message->getBody());
 
@@ -139,10 +144,8 @@ final class QueuePagerPersister implements PagerPersisterInterface
                     $data['options']
                 );
                 $this->dispatcher->dispatch($event);
-            }
-
-            if (microtime(true) > $limitTime) {
-                throw new \LogicException(sprintf('Overall reply time (%s seconds) has been exceeded.', $options['limit_overall_reply_time']));
+            } elseif (microtime(true) > $limitTime) {
+                throw new \LogicException(sprintf('No populate reply received within %s seconds; the consumers appear to be stuck.', $options['limit_overall_reply_time']));
             }
         }
 


### PR DESCRIPTION
In `QueuePagerPersister::insert()` the page-messages are all dispatched first, then the sender waits for replies with `limit_overall_reply_time` (default 180s) enforced as a **hard overall cap** on the reply-draining phase.

That cap is fine when the consumers clear the backlog quickly, but it trips for large indexes: if the consumers need more than 180s to drain after dispatch (slow/contended cluster, modest consumer count, big index), `insert()` aborts with `Overall reply time … exceeded` even though the consumers are healthy and still replying — leaving the populate failed but the index partially written.

This reworks the cap into an **idle timeout**: the deadline is pushed forward on every received reply, so a steady stream of replies completes regardless of total runtime, while a genuine stall (all consumers dead → no reply within the window) still aborts. The exception message is updated to reflect the new meaning.

Single-file change to the reply loop; no API or config change. `limit_overall_reply_time` now behaves as a per-reply idle window rather than a wall-clock budget for the whole drain.